### PR TITLE
Use a dataSource instead of setting input sources directly.

### DIFF
--- a/Example/MediaSlideshow.xcodeproj/project.pbxproj
+++ b/Example/MediaSlideshow.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		D0320BEC25A7B5B4003A1F54 /* UIImage+AspectFit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0320BE025A7B5B4003A1F54 /* UIImage+AspectFit.swift */; };
 		D0320BED25A7B5B4003A1F54 /* UIImageView+Tools.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0320BE125A7B5B4003A1F54 /* UIImageView+Tools.swift */; };
 		D0320BEE25A7B5B4003A1F54 /* ZoomAnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0320BE225A7B5B4003A1F54 /* ZoomAnimatedTransitioning.swift */; };
+		D0320C7F25A7C3A1003A1F54 /* MediaSlideshowSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0320C7D25A7C3A1003A1F54 /* MediaSlideshowSlide.swift */; };
+		D0320C8025A7C3A1003A1F54 /* MediaSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0320C7E25A7C3A1003A1F54 /* MediaSource.swift */; };
+		D0320C9725A7DA30003A1F54 /* ZoomableMediaSlideshowSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0320C9625A7DA30003A1F54 /* ZoomableMediaSlideshowSlide.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +75,9 @@
 		D0320BE025A7B5B4003A1F54 /* UIImage+AspectFit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIImage+AspectFit.swift"; path = "../../MediaSlideshow/Classes/Core/UIImage+AspectFit.swift"; sourceTree = "<group>"; };
 		D0320BE125A7B5B4003A1F54 /* UIImageView+Tools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIImageView+Tools.swift"; path = "../../MediaSlideshow/Classes/Core/UIImageView+Tools.swift"; sourceTree = "<group>"; };
 		D0320BE225A7B5B4003A1F54 /* ZoomAnimatedTransitioning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ZoomAnimatedTransitioning.swift; path = ../../MediaSlideshow/Classes/Core/ZoomAnimatedTransitioning.swift; sourceTree = "<group>"; };
+		D0320C7D25A7C3A1003A1F54 /* MediaSlideshowSlide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MediaSlideshowSlide.swift; path = ../../MediaSlideshow/Classes/Core/MediaSlideshowSlide.swift; sourceTree = "<group>"; };
+		D0320C7E25A7C3A1003A1F54 /* MediaSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MediaSource.swift; path = ../../MediaSlideshow/Classes/Core/MediaSource.swift; sourceTree = "<group>"; };
+		D0320C9625A7DA30003A1F54 /* ZoomableMediaSlideshowSlide.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ZoomableMediaSlideshowSlide.swift; path = ../../MediaSlideshow/Classes/Core/ZoomableMediaSlideshowSlide.swift; sourceTree = "<group>"; };
 		D0E8A9E21D97EB6D007EC517 /* MediaSlideshow-framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "MediaSlideshow-framework.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD45C56C18E7B8EC08371B86 /* Pods-ImageSlideshow_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ImageSlideshow_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ImageSlideshow_Example/Pods-ImageSlideshow_Example.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -202,12 +208,15 @@
 				D0320BDA25A7B5B4003A1F54 /* FullScreenSlideshowViewController.swift */,
 				D0320BDF25A7B5B4003A1F54 /* MediaSlideshow.swift */,
 				D0320BD925A7B5B4003A1F54 /* MediaSlideshowImageSlide.swift */,
+				D0320C7D25A7C3A1003A1F54 /* MediaSlideshowSlide.swift */,
+				D0320C7E25A7C3A1003A1F54 /* MediaSource.swift */,
 				D0320BD825A7B5B4003A1F54 /* ImageSource.swift */,
 				D0320BDD25A7B5B4003A1F54 /* PageIndicator.swift */,
 				D0320BDE25A7B5B4003A1F54 /* PageIndicatorPosition.swift */,
 				D0320BDB25A7B5B4003A1F54 /* SwiftSupport.swift */,
 				D0320BE025A7B5B4003A1F54 /* UIImage+AspectFit.swift */,
 				D0320BE125A7B5B4003A1F54 /* UIImageView+Tools.swift */,
+				D0320C9625A7DA30003A1F54 /* ZoomableMediaSlideshowSlide.swift */,
 				D0320BE225A7B5B4003A1F54 /* ZoomAnimatedTransitioning.swift */,
 				D0320BD625A7B553003A1F54 /* Info.plist */,
 				D0320BD525A7B553003A1F54 /* MediaSlideshow_framework.h */,
@@ -440,8 +449,11 @@
 				D0320BEA25A7B5B4003A1F54 /* PageIndicatorPosition.swift in Sources */,
 				D0320BE925A7B5B4003A1F54 /* PageIndicator.swift in Sources */,
 				D0320BEC25A7B5B4003A1F54 /* UIImage+AspectFit.swift in Sources */,
+				D0320C9725A7DA30003A1F54 /* ZoomableMediaSlideshowSlide.swift in Sources */,
+				D0320C7F25A7C3A1003A1F54 /* MediaSlideshowSlide.swift in Sources */,
 				D0320BED25A7B5B4003A1F54 /* UIImageView+Tools.swift in Sources */,
 				D0320BE525A7B5B4003A1F54 /* MediaSlideshowImageSlide.swift in Sources */,
+				D0320C8025A7C3A1003A1F54 /* MediaSource.swift in Sources */,
 				D0320BEB25A7B5B4003A1F54 /* MediaSlideshow.swift in Sources */,
 				D0320BEE25A7B5B4003A1F54 /* ZoomAnimatedTransitioning.swift in Sources */,
 			);

--- a/Example/MediaSlideshow/TableViewController.swift
+++ b/Example/MediaSlideshow/TableViewController.swift
@@ -47,7 +47,7 @@ class TableViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let fullScreenController = FullScreenSlideshowViewController()
-        fullScreenController.inputs = models.map { $0.inputSource }
+        fullScreenController.dataSource = ImageMediaSlideshowDataSource(sources: models.map { $0.inputSource })
         fullScreenController.initialPage = indexPath.row
 
         if let cell = tableView.cellForRow(at: indexPath), let imageView = cell.imageView {

--- a/Example/MediaSlideshow/ViewController.swift
+++ b/Example/MediaSlideshow/ViewController.swift
@@ -23,6 +23,9 @@ class ViewController: UIViewController {
     let sdWebImageSource = [SDWebImageSource(urlString: "https://images.unsplash.com/photo-1432679963831-2dab49187847?w=1080")!, SDWebImageSource(urlString: "https://images.unsplash.com/photo-1447746249824-4be4e1b76d66?w=1080")!, SDWebImageSource(urlString: "https://images.unsplash.com/photo-1463595373836-6e0b0a8ee322?w=1080")!]
     let kingfisherSource = [KingfisherSource(urlString: "https://images.unsplash.com/photo-1432679963831-2dab49187847?w=1080")!, KingfisherSource(urlString: "https://images.unsplash.com/photo-1447746249824-4be4e1b76d66?w=1080")!, KingfisherSource(urlString: "https://images.unsplash.com/photo-1463595373836-6e0b0a8ee322?w=1080")!]
 
+    // can be used with other sample sources as `afNetworkingSource`, `alamofireSource` or `sdWebImageSource` or `kingfisherSource`
+    lazy var dataSource = ImageMediaSlideshowDataSource(sources: localSource)
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -36,8 +39,8 @@ class ViewController: UIViewController {
         slideshow.activityIndicator = DefaultActivityIndicator()
         slideshow.delegate = self
 
-        // can be used with other sample sources as `afNetworkingSource`, `alamofireSource` or `sdWebImageSource` or `kingfisherSource`
-        slideshow.setImageInputs(localSource)
+        slideshow.dataSource = dataSource
+        slideshow.reloadData()
 
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(ViewController.didTap))
         slideshow.addGestureRecognizer(recognizer)

--- a/MediaSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/MediaSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -34,8 +34,8 @@ open class FullScreenSlideshowViewController: UIViewController {
     /// Index of initial image
     open var initialPage: Int = 0
 
-    /// Input sources to 
-    open var inputs: [ImageSource]?
+    /// Datasource
+    open var dataSource: MediaSlideshowDataSource?
 
     /// Background color
     open var backgroundColor = UIColor.black
@@ -65,9 +65,8 @@ open class FullScreenSlideshowViewController: UIViewController {
         view.backgroundColor = backgroundColor
         slideshow.backgroundColor = backgroundColor
 
-        if let inputs = inputs {
-            slideshow.setImageInputs(inputs)
-        }
+        slideshow.dataSource = dataSource
+        slideshow.reloadData()
 
         view.addSubview(slideshow)
 
@@ -93,10 +92,12 @@ open class FullScreenSlideshowViewController: UIViewController {
     override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        slideshow.slideshowSlides.forEach { $0.cancelPendingLoad() }
+        slideshow.slides.forEach { $0.willBeRemoved(from: slideshow) }
 
         // Prevents broken dismiss transition when image is zoomed in
-        slideshow.currentSlideshowItem?.zoomOut()
+        if let zoomable = slideshow.currentSlide as? ZoomableMediaSlideshowSlide {
+            zoomable.zoomOut()
+        }
     }
 
     open override func viewDidLayoutSubviews() {

--- a/MediaSlideshow/Classes/Core/ImageSource.swift
+++ b/MediaSlideshow/Classes/Core/ImageSource.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// A protocol that can be adapted by different Input Source providers
-@objc public protocol ImageSource {
+@objc public protocol ImageSource: MediaSource {
     /**
      Load image from the source to image view.
      - parameter imageView: Image view to load the image into.

--- a/MediaSlideshow/Classes/Core/MediaSlideshowSlide.swift
+++ b/MediaSlideshow/Classes/Core/MediaSlideshowSlide.swift
@@ -1,0 +1,24 @@
+//
+//  MediaSlideshowSlide.swift
+//  MediaSlideshow
+//
+//  Created by Peter Meyers on 1/7/21.
+//
+
+import UIKit
+
+public typealias MediaSlideshowSlideView = MediaSlideshowSlide & UIView
+
+@objc
+public protocol MediaSlideshowSlide {
+
+    var mediaContentMode: UIView.ContentMode { get set }
+
+    func transitionImageView() -> UIImageView
+
+    func willBeRemoved(from slideshow: MediaSlideshow)
+
+    func loadMedia()
+
+    func releaseMedia()
+}

--- a/MediaSlideshow/Classes/Core/MediaSource.swift
+++ b/MediaSlideshow/Classes/Core/MediaSource.swift
@@ -1,0 +1,12 @@
+//
+//  MediaSource.swift
+//  MediaSlideshow
+//
+//  Created by Peter Meyers on 1/7/21.
+//
+
+import Foundation
+
+/// A protocol that marks a media item in the slideshow.
+@objc public protocol MediaSource {
+}

--- a/MediaSlideshow/Classes/Core/ZoomableMediaSlideshowSlide.swift
+++ b/MediaSlideshow/Classes/Core/ZoomableMediaSlideshowSlide.swift
@@ -1,0 +1,29 @@
+//
+//  ZoomableMediaSlideshowSlide.swift
+//  MediaSlideshow
+//
+//  Created by Peter Meyers on 1/7/21.
+//
+
+import UIKit
+
+/// A slideshow item that can be further zoomed in after transitioning to fullscreen.
+public protocol ZoomableMediaSlideshowSlide: MediaSlideshowSlide {
+    var zoomInInitially: Bool { get }
+
+    var maximumZoomScale: CGFloat { get }
+
+    func isZoomed() -> Bool
+
+    func zoomOut()
+}
+
+extension ZoomableMediaSlideshowSlide where Self: UIScrollView {
+    public func isZoomed() -> Bool {
+        return self.zoomScale != self.minimumZoomScale
+    }
+
+    public func zoomOut() {
+        self.setZoomScale(minimumZoomScale, animated: false)
+    }
+}


### PR DESCRIPTION
This will allow clients to return their own custom slides depending on the type of input source, instead of always creating an Image slide.